### PR TITLE
Fixed test 5_12_4 for trailing comma cases

### DIFF
--- a/tests/5_dobby_container_runtime_test.sh
+++ b/tests/5_dobby_container_runtime_test.sh
@@ -389,7 +389,7 @@ test_5_12_4() {
         local output_1
 
         output=$(crun --root /run/rdk/crun list | grep $containername | awk '{print $4}')
-        output_1=$(cat $output/config.json | grep 'rootfsPropagation'  | awk '{print $2}' | sed 's/"//g')
+        output_1=$(cat $output/config.json | grep 'rootfsPropagation'  | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
 
         if [ "$output_1" == "rprivate"  ]; then
                 pass "$check"


### PR DESCRIPTION
Previously if "rootfsPropagation" parameter wasn't last it would have trailing comma i.e.: `"rootfsPropagation": "rprivate",` the rule was making this string looks like that: `rprivate,` and it was making successful cases to `Fail`. Now trailing comma will be deleted correctly (if any exists).