### PR TITLE
Added support for containers that logs to file in test_2_3

### DIFF
--- a/tests/2_dobby_daemon_configuration_test.sh
+++ b/tests/2_dobby_daemon_configuration_test.sh
@@ -38,22 +38,29 @@ test_2_1() {
 
 test_2_3() {
 	local testid="2.3"
-        local desc="Ensure the logging level is set to 'info'"
-        local check="$testid - $desc"
-        local output
+	local desc="Ensure the logging level is set to 'info'"
+	local check="$testid - $desc"
+	local output
 	local output_1
-	
-	output=$(crun --root /run/rdk/crun list | grep $containername | awk '{print $4}')
-	output_1=$(cat $output/config.json | grep LOG_INFO | awk '{print $2}' | sed 's/"//g')
-	
-	if [ "$output_1" == "LOG_INFO"  ]; then
-                pass "$check"
-                return
-        fi
-        fail "$check"
+	local sink
 
-	
+	output=$(crun --root /run/rdk/crun list | grep $containername | awk '{print $4}')
+	sink=$(cat $output/config.json | grep sink | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
+
+	if [ "$sink" != "file" ]; then
+		output_1=$(cat $output/config.json | grep priority | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
+		if [ "$output_1" == "LOG_INFO"  ]; then
+			pass "$check"
+		else
+			fail "$check"
+			verbosetxt "Priority different than LOG_INFO = $output_1"
+		fi
+	else
+		pass "$check"
+		verbosetxt "Logging to file doesn't require setting level"
+	fi
 }
+
 test_2_9() {
 	local testid="2.9"
 	local desc="Enable user namespace support"

--- a/tests/2_dobby_daemon_configuration_test.sh
+++ b/tests/2_dobby_daemon_configuration_test.sh
@@ -47,7 +47,10 @@ test_2_3() {
 	output=$(crun --root /run/rdk/crun list | grep $containername | awk '{print $4}')
 	sink=$(cat $output/config.json | grep sink | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
 
-	if [ "$sink" != "file" ]; then
+	# tolower sink, as it is case insensitive inside Dobby
+	sink=$(sed -e 's/\(.*\)/\L\1/' <<< "$sink")
+
+	if [ "$sink" != "file" -a "$sink" != "devnull" ]; then
 		output_1=$(cat $output/config.json | grep priority | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
 		if [ "$output_1" == "LOG_INFO"  ]; then
 			pass "$check"
@@ -57,7 +60,7 @@ test_2_3() {
 		fi
 	else
 		pass "$check"
-		verbosetxt "Logging to file doesn't require setting level"
+		verbosetxt "Logging to file or devnull doesn't require setting level"
 	fi
 }
 

--- a/tests/2_dobby_daemon_configuration_test.sh
+++ b/tests/2_dobby_daemon_configuration_test.sh
@@ -48,7 +48,7 @@ test_2_3() {
 	sink=$(cat $output/config.json | grep sink | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
 
 	# tolower sink, as it is case insensitive inside Dobby
-	sink=$(sed -e 's/\(.*\)/\L\1/' <<< "$sink")
+	sink=$(echo "$sink" | awk '{print tolower($0)}')
 
 	if [ "$sink" != "file" -a "$sink" != "devnull" ]; then
 		output_1=$(cat $output/config.json | grep priority | awk '{print $2}' | sed 's/"//g' | sed 's/,//g')


### PR DESCRIPTION
Some containers doesn't log to the journald. Instead they have per-container file to which all container logs are gathered. As there is one log per container logging level has no sense in those cases. Now we check what is the logging sink and for file we just pass test_2_3. In other cases we proceed like before.